### PR TITLE
BR-10/Delete-Soft - Function Delete Soft Minor Bug

### DIFF
--- a/app/controllers/post.controller.js
+++ b/app/controllers/post.controller.js
@@ -145,3 +145,23 @@ exports.deleteBulk = (req,res) => {
         })
     })
 }
+
+exports.deleteSoft = (req,res) => {
+    const id = req.query.id
+    const delsoft = {"softDeleted" : "true"}
+    Post.updateOne(id, delsoft)
+    .then ((result) => {
+        if (!result){
+            res.status(404).send({
+                message: "Post not found"
+            })
+        }
+        res.send({
+            message: "Post was soft deleted!"
+        })
+    }).catch((err) => {
+        res.status(409).send({
+            message: err.message || "Some error while soft deleted posts."
+        })
+    })
+}

--- a/app/routes/post.routes.js
+++ b/app/routes/post.routes.js
@@ -10,5 +10,6 @@ module.exports = (app) => {
     router.post('/insertbulk', posts.insertBulk)
     router.put('/', posts.updateBulk)
     router.delete('/', posts.deleteBulk)
+    router.put('/softdelete', posts.deleteSoft)
     app.use('/api/posts', router)
 }


### PR DESCRIPTION
Branch ini berisikan:
- Function Delete Soft User
- Menambah Routes untuk Delete Soft User

untuk testing API nya menggunakan POSTMAN
![image](https://user-images.githubusercontent.com/91597500/136095909-6540e949-fcfd-450e-ada9-cd43f13f79db.png)

lalu ketik dalam tab di postman dengan "localhost:8000/api/posts/softdelete", lalu ganti fungsi GET menjadi PUT, lalu pada bagian tab params isi "KEY" dengan id dan "Value" berisi ID User yang ada dalam data di Database, lalu send untuk memproses dan jika gagal akan ada message mengatakan bahwa proses delete soft gagal.

Minor Bug:
Saat menjalankan di POSTMAN pada "localhost:8000/api/posts/softdelete" maka akan terjadi sebuah error, sehingga fungsi tidak berjalan, akan tetapi code yang dipakai seharusnya work jika pada "localhost:8000/api/posts/softdelete" berjalan dengan lancar seperti layaknya pada "localhost:8000/api/posts/insertbulk" sebelumnya.